### PR TITLE
feat: open download window if uninstalled extension icon is selected

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/lib/components/extensionsConfig.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/components/extensionsConfig.ts
@@ -14,7 +14,7 @@ export interface ConfiguredExtension {
   injectedName: string;
   displayName: string;
   downloadUrl: {
-    browser?: Record<string, string>;
+    browser?: URL;
     app?: Record<string, string>;
   };
   logo: Logo;
@@ -37,10 +37,7 @@ export const extensionsConfig: ExtensionsConfig = {
     displayName: 'Polkadot',
     injectedName: 'polkadot-js',
     downloadUrl: {
-      browser: {
-        chrome: 'https://chrome.google.com/webstore/detail/talisman-polkadot-and-eth/fijngjgcjhjmmpcmkeiomlglpeiijkld',
-        firefox: 'https://addons.mozilla.org/en-US/firefox/addon/polkadot-js-extension/',
-      },
+      browser: new URL('https://polkadot.js.org/extension/'),
     },
     logo: { component: PolkadotIcon, size: '5em' },
   },
@@ -49,9 +46,7 @@ export const extensionsConfig: ExtensionsConfig = {
     displayName: 'Talisman',
     injectedName: 'talisman',
     downloadUrl: {
-      browser: {
-        chrome: 'https://chrome.google.com/webstore/detail/polkadot%7Bjs%7D-extension/mopnmbcafieddcagagdcbnhejhlodfdd',
-      },
+      browser: new URL('https://www.talisman.xyz/download'),
     },
     logo: { component: TalismanIcon, size: '5em' },
   },
@@ -60,9 +55,7 @@ export const extensionsConfig: ExtensionsConfig = {
     displayName: 'SubWallet',
     injectedName: 'subwallet-js',
     downloadUrl: {
-      browser: {
-        chrome: 'https://chrome.google.com/webstore/detail/subwallet-polkadot-wallet/onhogfjeacnfoofkfgppdlbmlmnplgbn',
-      },
+      browser: new URL('https://www.subwallet.app/download.html'),
       app: {
         apple: 'https://apps.apple.com/us/app/subwallet-polkadot-wallet/id1633050285',
         android: 'https://play.google.com/store/apps/details?id=app.subwallet.mobile',

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/+page.svelte
@@ -55,6 +55,8 @@
       if (isExtensionInstalled(injectedName)) {
         cachedExt.installed = true;
         CachedExtensionsStore.updateExtension(cachedExt);
+      } else if (extensionsConfig?.[injectedName]?.downloadUrl?.browser) {
+        window.open(extensionsConfig[injectedName].downloadUrl.browser, '_blank');
       }
     }
 


### PR DESCRIPTION
# Description
* Changes the `downloadUrl.browser` property of a configured wallet from `Record<string, string>` (which allowed for separate links for different browsers), to simply `URL`, a single link taking the user to the main download page for the extension. The main reasons for this are:
    * Not all extensions support all browsers
    * It avoids the need to perform complex user-agent detection, and simply lets the user pick the correct extension for their browser
* When an extension icon is clicked, if the extension has not been installed, a new window will be opened to allow the user to download & install the extension

Closes #24 