### PR TITLE
feat: delegation confirmation page styling, layout and logic

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/lib/components/PayloadConfirmation.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/lib/components/PayloadConfirmation.svelte
@@ -1,7 +1,13 @@
 <script lang="ts" context="module">
   export type PayloadSummaryItem = {
-    name: string;
-    content: string;
+    name?: string;
+
+    // NOTE: content can be HTML (we use the Svelte {@html ...} tag to render it).
+    //       This is a workaround for the fact that you can't dynamically iterate/build up
+    //       slot content in Svelte. It's "safe", because we control the content being rendered;
+    //       ie, everything comes from hard-coded app strings, chain constants or domain name, no
+    //       user-generated content or other request parameters.
+    content?: string;
   };
 </script>
 
@@ -9,10 +15,7 @@
   import { Content, Modal, Trigger } from 'sv-popup';
   import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
 
-  export let items: PayloadSummaryItem[] = [
-    { name: 'Message', content: 'Claim your handle' },
-    { name: 'URI', content: 'http://localhost.xxy' },
-  ];
+  export let items: PayloadSummaryItem[] = [];
   export let isRaw: boolean = false;
 
   export let payload: string | Uint8Array;
@@ -28,10 +31,10 @@
 
 <div>
   <div class="flex items-center justify-center pb-5">
-    <span class="text-md font-bold">Here is what you are going to sign</span>
+    <slot name="heading" />
   </div>
   <div class="flex items-center justify-center pb-3">
-    <span>Make sure to come back</span>
+    <slot name="subheading" />
   </div>
   <div class="flex items-center justify-center pb-5">
     <div class="flex h-[290px] w-full flex-col rounded-md border bg-transparent">
@@ -40,12 +43,17 @@
           {#if index > 0}
             <div class="pb-1 pt-2"><hr class="flex-grow pb-1 pt-2" /></div>
           {/if}
-          <div>
-            <span class="text-sm font-bold">{payloadItem.name ? payloadItem.name.replace(/:*$/, ':') : ''}</span>
-          </div>
-          <div>
-            <span class="text-sm font-normal">{@html payloadItem.content}</span>
-          </div>
+          {#if payloadItem?.name}
+            <div>
+              <span class="text-sm font-bold">{payloadItem.name.replace(/:*$/, ':')}</span>
+            </div>
+          {/if}
+          {#if payloadItem?.content}
+            <div>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              <span class="text-sm font-normal">{@html payloadItem.content}</span>
+            </div>
+          {/if}
         {/each}
       </div>
       <!-- PayloadDisplay -->
@@ -55,11 +63,11 @@
             <div class="whitespace-pre-wrap">
               The payload you will sign with your wallet should match the payload below:<br /><br />
             </div>
-            <div class="whitespace-pre-wrap">
+            <div>
               {#if isRaw}
                 <pre class="whitespace-pre-wrap">{payload}</pre>
               {:else}
-                {formatRawPayload()}
+                <pre class=" inline-block overflow-scroll">{formatRawPayload()}</pre>
               {/if}
             </div>
           </div>

--- a/packages/apps/frequency-wallet-proxy/src/lib/utils/DSNPSchemas.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/utils/DSNPSchemas.ts
@@ -1,5 +1,5 @@
 export interface SchemaData {
-  id: Record<string, unknown>;
+  id: Record<string, number>;
   description: string;
 }
 

--- a/packages/apps/frequency-wallet-proxy/src/lib/utils/index.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/utils/index.ts
@@ -59,32 +59,18 @@ export async function getPayloadSignature(
   }
 }
 
-export async function getDelegationAndPermissionSignature(
-  extensionName: string,
-  account: string,
+export async function getDelegationPayload(
   providerId: string,
-  schemasIds: number[]
-): Promise<{
-  signature: Uint8Array;
-  payload: { raw: { authorizedMsaId: string; expiration: number; schemaIds: number[] }; bytes: U8aLike };
-}> {
+  schemaIds: number[]
+): Promise<{ raw: { authorizedMsaId: string; expiration: number; schemaIds: number[] }; bytes: Uint8Array }> {
   const blockNumber = await getBlockNumber();
   const expiration = blockNumber + 50;
-  const addProviderPayload = await createAddProviderPayload(expiration, providerId, schemasIds);
+  const bytes = await createAddProviderPayload(expiration, providerId, schemaIds);
 
-  try {
-    const connector = new ExtensionConnector(window.injectedWeb3, APP_NAME);
-    await connector.connect(extensionName);
-
-    const signature = connector.signMessageWithWrappedBytes(addProviderPayload, account);
-    return {
-      signature,
-      payload: { raw: { authorizedMsaId: providerId, expiration, schemaIds: schemasIds }, bytes: addProviderPayload },
-    };
-  } catch (error) {
-    console.error('Error while signing message', error);
-    throw error;
-  }
+  return {
+    raw: { authorizedMsaId: providerId, expiration, schemaIds },
+    bytes,
+  };
 }
 
 export * from './DSNPSchemas';

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { SiwsMessage } from '@talismn/siws';
   import { generateSIWxNonce } from '@frequency-control-panel/utils';
-  import { Content, Modal, Trigger } from 'sv-popup';
   import { APP_NAME } from '$lib/globals';
   import { CurrentSelectedMsaAccountStore } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import { ConnectedExtensionsDerivedStore } from '$lib/stores/derived/ConnectedExtensionsDerivedStore';
@@ -42,7 +41,7 @@
       name: 'From',
       content: `${$CurrentSelectedMsaAccountStore.account.name}<br/>${payload.address}`,
     },
-    { name: 'Domain', content: /^.*:\/\/([^\/:]*)/.exec(payload.uri!)?.[1] || '' },
+    { name: 'Domain', content: /^.*:\/\/([^/:]*)/.exec(payload.uri!)?.[1] || '' },
     { name: 'Statement', content: payload.statement },
     { name: 'Chain Name', content: payload.chainName },
     { name: 'Nonce', content: payload.nonce },
@@ -56,7 +55,7 @@
     },
     {
       name: 'Additional Resources',
-      content: ((payload as unknown as any)['resources'] as any[]).reduce((prev, curr, index) => {
+      content: (payload as unknown as Record<string, string[]>)['resources'].reduce((prev, curr, index) => {
         return prev + (index > 0 ? '<br/>' : '') + curr;
       }, ''),
     },
@@ -79,5 +78,8 @@
   }
 </script>
 
-<PayloadConfirmation items={payloadSummary} payload={payload.prepareMessage()} isRaw={true} />
+<PayloadConfirmation items={payloadSummary} payload={payload.prepareMessage()} isRaw={true}>
+  <span slot="heading" class="text-md font-bold">Here is what you are going to sign</span>
+  <span slot="subheading">Make sure to come back</span>
+</PayloadConfirmation>
 <FooterButton on:click={signPayload}>Next > Sign</FooterButton>

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
@@ -56,5 +56,8 @@
   }
 </script>
 
-<PayloadConfirmation items={payloadSummary} payload={payload.bytes} />
+<PayloadConfirmation items={payloadSummary} payload={payload.bytes}>
+  <span slot="heading" class="text-md font-bold">Here is what you are going to sign</span>
+  <span slot="subheading">Make sure to come back</span>
+</PayloadConfirmation>
 <FooterButton on:click={handleHandle}>Next > Sign</FooterButton>

--- a/packages/utils/src/frequency/helpers.ts
+++ b/packages/utils/src/frequency/helpers.ts
@@ -84,10 +84,9 @@ export async function buildHandleTx(
 
 export async function buildCreateSponsoredAccountTx(
   controlKey: string,
-  providerKey: string,
-  signature: string,
+  proof: { Sr25519: string },
   payload: Uint8Array
-): Promise<Uint8Array> {
+): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
   const api = await getApi();
-  return api.tx.msa.createSponsoredAccount(controlKey, providerKey, signature, payload).toU8a();
+  return api.tx.msa.createSponsoredAccountWithDelegation(controlKey, proof, payload);
 }

--- a/packages/utils/src/wallet-proxy/config.ts
+++ b/packages/utils/src/wallet-proxy/config.ts
@@ -10,7 +10,7 @@ const defaultSchemas: Schema[] = [
   Schema.PUBLIC_KEY,
   Schema.PUBLIC_FOLLOWS,
   Schema.PRIVATE_FOLLOWS,
-  Schema.PRVIATE_CONNECTIONS,
+  Schema.PRIVATE_CONNECTIONS,
 ];
 
 export interface Config {

--- a/packages/utils/src/wallet-proxy/enums.ts
+++ b/packages/utils/src/wallet-proxy/enums.ts
@@ -14,7 +14,7 @@ export enum Schema {
   PUBLIC_KEY = 'publicKey',
   PUBLIC_FOLLOWS = 'publicFollows',
   PRIVATE_FOLLOWS = 'privateFollows',
-  PRVIATE_CONNECTIONS = 'privateConnections',
+  PRIVATE_CONNECTIONS = 'privateConnections',
 }
 
 export enum ProxyUrl {


### PR DESCRIPTION
# Description
- Adds styling for the delegation page
- Adds layout and text copy for the delegation page
- Adds the ability to sign the delegation payload and generate the `createSponsoredAccountWithDelegation` extrinsic call

<img width="426" alt="image" src="https://github.com/AmplicaLabs/frequency-control-panel/assets/83412778/16d09174-5a67-46d9-9097-1df3e7cc83c6">

Closes #86 
