### PR TITLE
feat(messaging): add response payload

### DIFF
--- a/packages/apps/example/src/routes/+page.svelte
+++ b/packages/apps/example/src/routes/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-  import { signIn } from '@frequency-control-panel/utils';
+  import { getLoginOrRegistrationPayload } from '@frequency-control-panel/utils';
+  let signInResponse: unknown;
+
+  const handleSignIn = async () => {
+    signInResponse = await getLoginOrRegistrationPayload();
+  };
 
   let signatures: Record<string, unknown> = {};
 </script>
 
 <div class="p-12 text-violet-300">
   <h1 class="text-3xl">Welcome to ACME!</h1>
-  <button class="btn-primary bg-violet-400" on:click|preventDefault={() => signIn()} disabled={false}>
+  <button class="btn-primary bg-violet-400" on:click|preventDefault={handleSignIn} disabled={false}>
     Login with Frequency Connect
   </button>
   <div class="mt-12">
@@ -18,5 +23,8 @@
     {:else}
       <p class="mt-4">Please click 'Login'</p>
     {/if}
+  </div>
+  <div>
+	{signInResponse && JSON.stringify(signInResponse)}
   </div>
 </div>

--- a/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
@@ -1,4 +1,4 @@
-import { type SignInRequest } from '@frequency-control-panel/utils';
+import type { SignInRequest, SignInResponse, SignUpResponse } from '@frequency-control-panel/utils';
 import { writable } from 'svelte/store';
 
 export type AugmentedSignInRequest = SignInRequest & {
@@ -7,9 +7,45 @@ export type AugmentedSignInRequest = SignInRequest & {
 
 export type RequestResponseData = {
   request: AugmentedSignInRequest;
-  response?: unknown;
+  response?: { signIn?: SignInResponse; signUp?: SignUpResponse };
 };
 
-export const RequestResponseStore = writable<RequestResponseData>({
-  request: { providerId: '', providerName: '', requiredSchemas: [] },
-});
+function createRequestResponseStore() {
+  const { subscribe, set, update } = writable<RequestResponseData>({
+    request: { providerId: '', providerName: '', requiredSchemas: [] },
+  });
+
+  return {
+    set,
+    subscribe,
+    update,
+    updateSignInResponse: (newSignInResponse: SignInResponse) =>
+      update((store) => ({
+        ...store,
+        response: { ...store.response, signIn: newSignInResponse },
+      })),
+    updateEncodedClaimHandle: (newEncodedClaimHandle: `0x${string}`) =>
+      update((store) => ({
+        ...store,
+        response: {
+          ...store.response,
+          signUp: { ...store.response?.signUp, encodedClaimHandle: newEncodedClaimHandle },
+        },
+      })),
+    updateEncodedCreateSponsoredAccountWithDelegation: (
+      newEncodedCreateSponsoredAccountWithDelegation: `0x${string}`
+    ) =>
+      update((store) => ({
+        ...store,
+        response: {
+          ...store.response,
+        },
+        signUp: {
+          ...store.response?.signUp,
+          encodedCreateSponsoredAccountWithDelegation: newEncodedCreateSponsoredAccountWithDelegation,
+        },
+      })),
+  };
+}
+
+export const RequestResponseStore = createRequestResponseStore();

--- a/packages/apps/frequency-wallet-proxy/src/lib/utils/index.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/utils/index.ts
@@ -7,6 +7,9 @@ import {
 } from '@frequency-control-panel/utils';
 import { APP_NAME } from '$lib/globals';
 import type { U8aLike } from '@polkadot/util/types';
+import { Message, WindowEndpoint } from '@frequency-control-panel/utils';
+import type { SignInResponse, SignUpResponse } from '@frequency-wallet-proxy/types';
+
 
 export async function checkHandleAvailability(handle: string): Promise<boolean> {
   const minAvailableHandles = 5;
@@ -71,6 +74,22 @@ export async function getDelegationPayload(
     raw: { authorizedMsaId: providerId, expiration, schemaIds },
     bytes,
   };
+}
+
+let windowEndpoint: WindowEndpoint | undefined;
+
+export const getWindowEndpoint = async () => {
+    return windowEndpoint ?? (windowEndpoint = await WindowEndpoint.create());
+};
+
+export const sendSignUpMessageResponse = async (message: SignUpResponse) => {
+    const endpoint = await getWindowEndpoint();
+    endpoint.sendEvent(Message.SignUpMessage, message);
+}
+
+export const sendSignInMessageResponse = async (message: SignInResponse) => {
+    const endpoint = await getWindowEndpoint();
+    endpoint.sendEvent(Message.SignInMessage, message);
 }
 
 export * from './DSNPSchemas';

--- a/packages/apps/frequency-wallet-proxy/src/routes/+layout.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/+layout.svelte
@@ -7,10 +7,11 @@
     resolveSchemas,
     setApiUrl,
     type SignInRequest,
-    WindowEndpoint,
   } from '@frequency-control-panel/utils';
   import { RequestResponseStore } from '$lib/stores/RequestResponseStore';
   import { page } from '$app/stores';
+  import { getWindowEndpoint } from '$lib/utils';
+  import { SignupStore } from '$lib/stores/SignupStore';
 
   async function handleSigninPayload(e: CustomEvent) {
     setApiUrl($page.url.searchParams.get('frequencyRpcUrl'));
@@ -23,7 +24,7 @@
   onMount(() => {
     resolveInjectedWeb3(window.injectedWeb3);
     if (window.opener) {
-      WindowEndpoint.create()
+      getWindowEndpoint()
         .then((endpoint) => {
           endpoint.on('signinPayload', handleSigninPayload);
         })

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { SiwsMessage } from '@talismn/siws';
-  import { generateSIWxNonce } from '@frequency-control-panel/utils';
+  import { generateSIWxNonce, type SignInResponse } from '@frequency-control-panel/utils';
   import { CurrentSelectedMsaAccountStore } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import { ConnectedExtensionsDerivedStore } from '$lib/stores/derived/ConnectedExtensionsDerivedStore';
+  import { RequestResponseStore } from '$lib/stores/RequestResponseStore';
   import PayloadConfirmation, { type PayloadSummaryItem } from '$lib/components/PayloadConfirmation.svelte';
   import FooterButton from '$lib/components/FooterButton.svelte';
+  import { sendSignInMessageResponse } from '$lib/utils';
 
   const now = new Date();
   const payload: SiwsMessage = new SiwsMessage({
@@ -75,6 +77,14 @@
     }
 
     const { signature, message } = await payload.sign(extension.connector.injectedExtension!);
+
+    const signInMessage: SignInResponse = {
+      siwsPayload: { message, signature },
+    };
+
+    RequestResponseStore.updateSignInResponse(signInMessage);
+
+    await sendSignInMessageResponse(signInMessage);
     console.info(`Message:
     ${message}
 

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/delegation/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/delegation/+page.svelte
@@ -6,6 +6,8 @@
   import PayloadConfirmation, { type PayloadSummaryItem } from '$lib/components/PayloadConfirmation.svelte';
   import { buildCreateSponsoredAccountTx } from '@frequency-control-panel/utils';
   import { RequestResponseStore } from '$lib/stores/RequestResponseStore';
+  import { sendSignUpMessageResponse } from '$lib/utils';
+  import type { SignUpResponse } from '@frequency-control-panel/utils/types';
 
   let payloadBytes: Uint8Array;
 
@@ -52,7 +54,16 @@
         )
       ).toHex();
 
+      RequestResponseStore.updateEncodedCreateSponsoredAccountWithDelegation(encodedExtrinsic);
+
       console.dir({ msg: 'Signature', signature, tx: encodedExtrinsic });
+
+      const response: SignUpResponse = {
+        encodedClaimHandle: $RequestResponseStore.response?.signUp?.encodedClaimHandle,
+        encodedCreateSponsoredAccountWithDelegation:
+          $RequestResponseStore.response?.signUp?.encodedCreateSponsoredAccountWithDelegation,
+      };
+      await sendSignUpMessageResponse(response);
 
       // TODO: store result in SignupStore. Either the signed payload or the encoded extrinsic (not sure which yet)
     } catch (err: unknown) {

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
@@ -3,6 +3,7 @@
   import type { PayloadSummaryItem } from '$lib/components/PayloadConfirmation.svelte';
   import { CurrentSelectedExtensionIdStore } from '$lib/stores/CurrentSelectedExtensionIdStore';
   import { SignupStore } from '$lib/stores/SignupStore';
+  import { RequestResponseStore } from '$lib/stores/RequestResponseStore';
   import { getHandlePayload, getPayloadSignature } from '$lib/utils';
   import { buildHandleTx } from '@frequency-control-panel/utils';
   import { goto } from '$app/navigation';
@@ -35,7 +36,7 @@
         payload.bytes
       );
 
-      const _encodeClaimHandleTx = (
+      const encodeClaimHandleTx = (
         await buildHandleTx(
           $SignupStore.address,
           {
@@ -45,7 +46,9 @@
         )
       ).toHex();
 
-      console.dir({ msg: 'Signature', signature, tx: _encodeClaimHandleTx });
+      RequestResponseStore.updateEncodedClaimHandle(encodeClaimHandleTx);
+
+      console.dir({ msg: 'Signature', signature, tx: encodeClaimHandleTx });
 
       // TODO: store result in SignupStore. Either the signed payload or the encoded extrinsic (not sure which yet)
 

--- a/packages/utils/src/wallet-proxy/helpers.ts
+++ b/packages/utils/src/wallet-proxy/helpers.ts
@@ -1,0 +1,12 @@
+import { ControlPanelResponse, SignInResponse, SignUpResponse } from './types';
+
+export function isSignIn(payload: ControlPanelResponse): payload is SignInResponse {
+  return (payload as SignInResponse).siwsPayload !== undefined;
+}
+
+export function isSignUp(payload: ControlPanelResponse): payload is SignUpResponse {
+  return (
+    (payload as SignUpResponse).encodedClaimHandle !== undefined ||
+    (payload as SignUpResponse).encodedCreateSponsoredAccountWithDelegation !== undefined
+  );
+}

--- a/packages/utils/src/wallet-proxy/index.ts
+++ b/packages/utils/src/wallet-proxy/index.ts
@@ -2,3 +2,4 @@ export * from './enums';
 export * from './config';
 export * from './popup';
 export * from './messenger';
+export * from './types';

--- a/packages/utils/src/wallet-proxy/messenger/enums.ts
+++ b/packages/utils/src/wallet-proxy/messenger/enums.ts
@@ -1,5 +1,7 @@
 export enum Message {
   Handshake = 'handshake',
+  SignUpMessage = 'signUpMessage',
+  SignInMessage = 'signInMessage',
 }
 
 export enum ErrorMessage {

--- a/packages/utils/src/wallet-proxy/messenger/index.ts
+++ b/packages/utils/src/wallet-proxy/messenger/index.ts
@@ -2,3 +2,4 @@ export * from './enums';
 export * from './types';
 export * from './window-messenger';
 export * from './window-endpoint';
+export * from './enums';

--- a/packages/utils/src/wallet-proxy/messenger/window-messenger.ts
+++ b/packages/utils/src/wallet-proxy/messenger/window-messenger.ts
@@ -77,4 +77,8 @@ export class WindowMessenger {
     };
     this.eventTarget.removeEventListener(eventName, eventListener);
   }
+
+  public dispose() {
+    this.channel.port1.close();
+  }
 }

--- a/packages/utils/src/wallet-proxy/popup.ts
+++ b/packages/utils/src/wallet-proxy/popup.ts
@@ -1,34 +1,81 @@
 import { objectToQueryString } from '../misc_utils';
+import { ControlPanelResponse, SignInResponse, SignUpResponse } from './types';
+import { Message } from './messenger/enums';
 import { getConfig } from './config';
 import { SignInRequest, WindowMessenger } from './messenger';
 
+let windowMessenger: WindowMessenger;
+
 export async function renderPopup(src: string, frequencyRpcUrl: string) {
-  const messenger = await WindowMessenger.create(
-    `${src}/signin?${objectToQueryString({ frequencyRpcUrl })}`,
-    'width=600, height=800 screenX=400 screenY=100'
-  );
-
-  if (!messenger.childWindow) {
-    throw new Error('Popup was blocked');
+  try {
+    windowMessenger = await WindowMessenger.create(
+      `${src}/signin?${objectToQueryString({ frequencyRpcUrl })}`,
+      'width=600, height=800 screenX=400 screenY=100'
+    );
+  } catch (error) {
+    console.error('Error while creating window messenger', e);
+    throw error;
   }
-
-  return messenger;
 }
 
-export async function signIn() {
+export async function getLoginOrRegistrationPayload(): Promise<ControlPanelResponse> {
+  const checkPopupClosed = setInterval(function () {
+    if (windowMessenger?.childWindow?.closed) {
+      clearInterval(checkPopupClosed);
+    }
+  }, 500);
+
+  let payload;
+  try {
+    payload = await doGetLoginOrRegistrationPayload();
+  } finally {
+    if (checkPopupClosed) {
+      clearInterval(checkPopupClosed);
+    }
+    windowMessenger.childWindow?.close();
+    windowMessenger.dispose();
+  }
+
+  return payload;
+}
+
+async function doGetLoginOrRegistrationPayload(): Promise<ControlPanelResponse> {
   const { providerId, proxyUrl, frequencyRpcUrl, schemas } = getConfig();
 
   const signInRequest: SignInRequest = {
     providerId,
     requiredSchemas: schemas,
   };
-  const popupUrl = proxyUrl;
 
-  const messenger: WindowMessenger = await renderPopup(popupUrl, frequencyRpcUrl);
-  messenger.sendEvent('signinPayload', signInRequest);
-  const checkPopupClosed = setInterval(function () {
-    if (messenger.childWindow && messenger.childWindow.closed) {
-      clearInterval(checkPopupClosed);
-    }
-  }, 500);
+  await renderPopup(proxyUrl, frequencyRpcUrl);
+
+  windowMessenger.sendEvent('signinPayload', signInRequest);
+
+  return new Promise((resolve, _reject) => {
+    windowMessenger.on(Message.SignInMessage, (data) => {
+      const response: ControlPanelResponse = {
+        type: 'sign-in',
+        data: {
+          siwsPayload: data.detail.siwsPayload,
+        } as SignInResponse,
+      };
+
+      return resolve(response);
+    });
+
+    windowMessenger.on(Message.SignUpMessage, (data) => {
+      const {
+        detail: { encodedClaimHandle, encodedCreateSponsoredAccountWithDelegation },
+      } = data;
+      const response: ControlPanelResponse = {
+        type: 'sign-up',
+        data: {
+          encodedClaimHandle,
+          encodedCreateSponsoredAccountWithDelegation,
+        } as SignUpResponse,
+      };
+
+      return resolve(response);
+    });
+  });
 }

--- a/packages/utils/src/wallet-proxy/types.ts
+++ b/packages/utils/src/wallet-proxy/types.ts
@@ -1,0 +1,24 @@
+export type SiwsPayload = {
+  message: string;
+  signature: string;
+};
+
+export type ErrorResponse = {
+  message: string;
+};
+
+export type SignInResponse = {
+  siwsPayload?: SiwsPayload;
+  error?: ErrorResponse;
+};
+
+export type SignUpResponse = {
+  encodedClaimHandle?: `0x${string}`;
+  encodedCreateSponsoredAccountWithDelegation?: `0x${string}`;
+  error?: ErrorResponse;
+};
+
+export type ControlPanelResponse = (SignInResponse | SignUpResponse) & {
+  type?: 'sign-in' | 'sign-up';
+  data: SignUpResponse | SignInResponse;
+};


### PR DESCRIPTION
Add the ability for a client to receive a sign-in or sign-up payload after completing
their corresponding flows in the control panel.

#67 