### PR TITLE
fix(response): return encoded data

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
@@ -39,10 +39,10 @@ function createRequestResponseStore() {
         ...store,
         response: {
           ...store.response,
-        },
-        signUp: {
-          ...store.response?.signUp,
-          encodedCreateSponsoredAccountWithDelegation: newEncodedCreateSponsoredAccountWithDelegation,
+          signUp: {
+            ...store.response?.signUp,
+            encodedCreateSponsoredAccountWithDelegation: newEncodedCreateSponsoredAccountWithDelegation,
+          },
         },
       })),
   };


### PR DESCRIPTION
Ensure that encodedCreateSponsoredAccountWithDelegation is returned as part of the response.