### PR TITLE
feat: honor last used msa and key for signin

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/lib/components/MsaAndAccountSelector.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/lib/components/MsaAndAccountSelector.svelte
@@ -4,11 +4,7 @@
   import { type CurrentSelectedMsaAccount } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import { getHandleBase, getHandleSuffix } from '@frequency-control-panel/utils';
   import WalletAddressSelector from './WalletAddressSelector.svelte';
-
-  type MsaAndAddress = {
-    msaId: string;
-    address: string;
-  };
+  import type { MsaAndAddress } from '$lib/stores/CachedLastUsedMsaAndAddressStore';
 
   export let msaEntries: MsaInfoWithAccounts[] = [];
   export let selectedMsaWithAccount: CurrentSelectedMsaAccount;

--- a/packages/apps/frequency-wallet-proxy/src/lib/components/WalletAddressSelector.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/lib/components/WalletAddressSelector.svelte
@@ -37,7 +37,11 @@
   }
 
   $: if (!_selectedAddress) {
-    _selectedAddress = initialSelectedAddress || accounts?.[0]?.address;
+    if (initialSelectedAddress && accounts.find((account) => account.address === initialSelectedAddress)) {
+      _selectedAddress = initialSelectedAddress;
+    } else {
+      _selectedAddress = accounts?.[0]?.address;
+    }
   }
 </script>
 

--- a/packages/apps/frequency-wallet-proxy/src/lib/stores/CachedLastUsedMsaAndAddressStore.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/stores/CachedLastUsedMsaAndAddressStore.ts
@@ -1,0 +1,8 @@
+import { storable } from './storable';
+
+export type MsaAndAddress = {
+  msaId: string;
+  address: string;
+};
+
+export const CachedLastUsedMsaAndAddressStore = storable<MsaAndAddress>('LastUsedMsaAndAddress');

--- a/packages/apps/frequency-wallet-proxy/src/lib/stores/CurrentSelectedMsaAccountStore.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/stores/CurrentSelectedMsaAccountStore.ts
@@ -1,9 +1,9 @@
+import { writable } from 'svelte/store';
 import { type MsaInfo } from '@frequency-control-panel/utils';
-import { storable } from './storable';
 import type { InjectedAccountWithExtensions } from './derived/AllAccountsDerivedStore';
 
 export interface CurrentSelectedMsaAccount extends MsaInfo {
   account: InjectedAccountWithExtensions;
 }
 
-export const CurrentSelectedMsaAccountStore = storable<CurrentSelectedMsaAccount>('SelectedMsaAccount');
+export const CurrentSelectedMsaAccountStore = writable<CurrentSelectedMsaAccount>();

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
@@ -7,9 +7,12 @@
   } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import MsaAndAccountSelector from '$lib/components/MsaAndAccountSelector.svelte';
   import FooterButton from '$lib/components/FooterButton.svelte';
+  import { CachedLastUsedMsaAndAddressStore, type MsaAndAddress } from '$lib/stores/CachedLastUsedMsaAndAddressStore';
+  import { onMount } from 'svelte';
 
   let selectedMsaWithAccount: CurrentSelectedMsaAccount;
   let msaMap: MsaMap = {};
+  let initialSelection: MsaAndAddress;
 
   $: nextEnabled = !!selectedMsaWithAccount;
 
@@ -23,22 +26,28 @@
 
   function handleNext() {
     if (nextEnabled) {
+      $CachedLastUsedMsaAndAddressStore = {
+        msaId: selectedMsaWithAccount.msaId,
+        address: selectedMsaWithAccount.account.address,
+      };
       goto('/signin/confirm');
     } else {
       console.error('Button not enabled');
     }
   }
+
+  onMount(() => {
+    if ($CachedLastUsedMsaAndAddressStore) {
+      initialSelection = $CachedLastUsedMsaAndAddressStore;
+    }
+  });
 </script>
 
 <div class="flex h-full items-center justify-center pb-9">
   <span class=" text-[16px] font-bold">Choose a handle to sign in with</span>
 </div>
 <div class="pb-[64px]">
-  <MsaAndAccountSelector
-    msaEntries={Object.values(msaMap)}
-    bind:selectedMsaWithAccount
-    initialSelection={{ msaId: '', address: '' }}
-  />
+  <MsaAndAccountSelector msaEntries={Object.values(msaMap)} bind:selectedMsaWithAccount {initialSelection} />
 </div>
 <FooterButton on:click={handleNext}>Next > Sign In</FooterButton>
 <div class="flex items-center justify-center pt-8">


### PR DESCRIPTION
# Description
This PR adds the ability for the app to remember the MSA and public key last used for sign-in, and pre-select it in the account selection page if present.

* Add new browser local store, `CachedLastUsedMsaAndAddress` store to save MSA and public key address last used for sign-in
* Change `CurrentSelectedMsaAccountStore` from `storable` to `writable`, as we don't need to cache this in the browser any more
* Honor previous selection if present

Closes #18 