### PR TITLE
chore(deployment): deploy to GitHub pages 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ['main', 'chore/publish-to-gh-pages-issue-107']
+env:
+  BUILD_TARGET: 'production'
+jobs:
+  build_site:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: build
+        env:
+          BASE_PATH: '/control-panel'
+        run: |
+          pnpm run build
+      - name: structure 
+        run: |
+          mkdir control-panel
+          touch control-panel/.nojekyll
+          mkdir control-panel/example
+          mkdir control-panel/wallet-proxy
+          mv ./packages/apps/frequency-wallet-proxy/build/* ./control-panel/wallet-proxy
+          mv ./packages/apps/example/build/* ./control-panel/example
+
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # this should match the `pages` option in adapter-static options
+          path: 'control-panel/'
+
+  deploy:
+    needs: build_site
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/packages/apps/example/src/routes/+page.svelte
+++ b/packages/apps/example/src/routes/+page.svelte
@@ -4,11 +4,19 @@
     getLoginOrRegistrationPayload,
     isSignIn,
     isSignUp,
+    setConfig,
     type SignUpResponse,
   } from '@frequency-control-panel/utils';
   import SignInVerification from '$lib/components/SignInVerification.svelte';
   import { parseMessage, SiwsMessage } from '@talismn/siws';
   import AccountCreator from '$lib/components/AccountCreator.svelte';
+  
+  if (process.env.BUILD_TARGET === "production") {
+    setConfig({
+      proxyUrl: "https://amplicalabs.github.io/frequency-control-panel/wallet-proxy",
+      frequencyRpcUrl: "https://rpc.rococo.frequency.xyz",
+    })
+  }
 
   let signInResponse: ControlPanelResponse | undefined;
   let signInPayload: SiwsMessage;

--- a/packages/apps/example/vite.config.ts
+++ b/packages/apps/example/vite.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
     environment: 'jsdom',
     mockReset: true,
   },
+  define: {  'process.env.BUILD_TARGET': JSON.stringify(process.env.BUILD_TARGET) },
 });


### PR DESCRIPTION
Deploy Example application and Wallet-Proxy to GitHub Pages.
Update example application to open Wallet-Proxy deployed to
GitHub pages when the build is set to production.

#107 