### PR TITLE
chore(config): update svelte base path

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/+page.svelte
@@ -14,6 +14,7 @@
   import { goto } from '$app/navigation';
   import { FilteredMsaAccountsDerivedStore } from '$lib/stores/derived/MsaAccountsDerivedStore';
   import { page } from '$app/stores';
+  import { base } from '$app/paths';
 
   const getErrorMessage = (error: unknown) => {
     if (error instanceof Error) return error.message;
@@ -64,9 +65,9 @@
     if (cachedExt.installed && cachedExt.authorized === ExtensionAuthorizationEnum.Authorized) {
       CurrentSelectedExtensionIdStore.set(cachedExt.injectedName);
       if (Object.keys(await $FilteredMsaAccountsDerivedStore).length === 0) {
-        goto(`/signup/handle?${$page.url.searchParams}`);
+        goto(`${base}/signup/handle?${$page.url.searchParams}`);
       } else {
-        goto('/signin/accounts');
+        goto(`${base}/signin/accounts`);
       }
     }
   };

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
@@ -7,6 +7,7 @@
   } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import MsaAndAccountSelector from '$lib/components/MsaAndAccountSelector.svelte';
   import FooterButton from '$lib/components/FooterButton.svelte';
+  import { base } from '$app/paths';
   import { CachedLastUsedMsaAndAddressStore, type MsaAndAddress } from '$lib/stores/CachedLastUsedMsaAndAddressStore';
   import { onMount } from 'svelte';
 
@@ -30,7 +31,7 @@
         msaId: selectedMsaWithAccount.msaId,
         address: selectedMsaWithAccount.account.address,
       };
-      goto('/signin/confirm');
+      goto(`${base}/signin/confirm`);
     } else {
       console.error('Button not enabled');
     }

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/handle-confirmation/+page.svelte
@@ -7,6 +7,7 @@
   import { getHandlePayload, getPayloadSignature } from '$lib/utils';
   import { buildHandleTx } from '@frequency-control-panel/utils';
   import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
 
   let payload: Awaited<ReturnType<typeof getHandlePayload>>;
   let payloadSummary: PayloadSummaryItem[];
@@ -52,7 +53,7 @@
 
       // TODO: store result in SignupStore. Either the signed payload or the encoded extrinsic (not sure which yet)
 
-      goto('/signup/delegation');
+      goto(`${base}/signup/delegation`);
     } catch (err: unknown) {
       console.error('Payload not signed', err);
     }

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/handle/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/handle/+page.svelte
@@ -7,6 +7,7 @@
   import { FilteredNonMsaAccountsDerivedStore } from '$lib/stores/derived/MsaAccountsDerivedStore';
   import FooterButton from '$lib/components/FooterButton.svelte';
   import { getHandlePayload } from '$lib/utils';
+  import { base } from '$app/paths';
 
   let selectedAddress: string;
   let selectedAccount: InjectedAccountWithExtensions;
@@ -27,7 +28,7 @@
   async function handleNext() {
     const payload = await getHandlePayload($SignupStore.handle.baseHandle);
     $SignupStore.handle.payload = payload;
-    goto('/signup/handle-confirmation');
+    goto(`${base}/signup/handle-confirmation`);
   }
 </script>
 

--- a/packages/apps/frequency-wallet-proxy/svelte.config.js
+++ b/packages/apps/frequency-wallet-proxy/svelte.config.js
@@ -1,6 +1,8 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+const production = process.env.BUILD_TARGET === 'production';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   // Consult https://kit.svelte.dev/docs/integrations#preprocessors
@@ -12,6 +14,9 @@ const config = {
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
+    paths: {
+      base: production ? '/frequency-control-panel/wallet-proxy' : ''
+    }
   },
 };
 


### PR DESCRIPTION
Update the Svelte config so that it builds
with a different base path depending on
development vs production build.

This allows a different base URL to be
the root of the application.

#127 