### PR TITLE
feat(example): display response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ['main', 'chore/publish-to-gh-pages-issue-107']
+    branches: ['main']
 env:
   BUILD_TARGET: 'production'
 jobs:

--- a/packages/apps/example/src/lib/components/AccountCreator.svelte
+++ b/packages/apps/example/src/lib/components/AccountCreator.svelte
@@ -51,7 +51,7 @@
   });
 </script>
 
-<div class="flex">Creating account</div>
+<div class="flex text-2xl">Creating account</div>
 {#if error}
   <div class="flex pb-3 font-bold">{error}</div>
 {/if}

--- a/packages/apps/example/src/routes/+page.svelte
+++ b/packages/apps/example/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import AccountCreator from '$lib/components/AccountCreator.svelte';
   import { MultiSelect, type ObjectOption, type Option } from 'svelte-multiselect';
   import { type SchemaName, schemas } from '@dsnp/frequency-schemas/dsnp';
+  import Spinner from '../lib/components/Spinner.svelte';
 
   if (process.env.BUILD_TARGET === 'production') {
     setConfig({
@@ -75,6 +76,7 @@
   let requestedSchemas: Option[] = defaultConfig.schemas.map((s) => ({ label: s.name, value: s.name, id: s.id }));
   let options = [...schemas.keys()];
   let providerId: number = 1;
+  let isFetchingPayload = false;
 
   let signUpPayload: SignUpResponse;
 
@@ -91,7 +93,9 @@
     };
     setConfig(config);
     walletProxyResponse = undefined;
+    isFetchingPayload = true;
     walletProxyResponse = await getLoginOrRegistrationPayload();
+    isFetchingPayload = false;
   };
 
   $: {
@@ -134,6 +138,15 @@
     <input type="text" placeholder="300" bind:value={expirationSeconds} />
     <label for="schemas">Requested schemas</label>
     <MultiSelect bind:selected={requestedSchemas} {options}></MultiSelect>
+  </div>
+  <div class="mt-12">
+    <h1 class="text-2xl">Wallet Proxy Response Payload</h1>
+    {#if isFetchingPayload}
+      <Spinner />
+    {/if}
+    {#if !isFetchingPayload && walletProxyResponse}
+      <pre>{JSON.stringify(walletProxyResponse, null, 4)}</pre>
+    {/if}
   </div>
   <div class="mt-12">
     {#if walletProxyResponse}


### PR DESCRIPTION
Display response payload from Wallet-Proxy
in Example application. This allows developers
to see what data is being returned from Wallet-Proxy.

#138 