### PR TITLE
fix: styling on handle wallet address selector

### DIFF
--- a/packages/apps/frequency-wallet-proxy/src/lib/components/WalletAddressSelector.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/lib/components/WalletAddressSelector.svelte
@@ -61,7 +61,7 @@
     </select>
   </div>
 {:else}
-  <div class=" flow-root">
+  <div class="flow-root">
     <div>
       <span class="float-left text-sm font-semibold">{label}</span>
     </div>

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/accounts/+page.svelte
@@ -67,5 +67,5 @@
 </div>
 <FooterButton on:click={handleNext}>Next > Sign In</FooterButton>
 <div class="flex items-center justify-center pt-8">
-  <a href="/signup/handle" class="text-center text-sm font-semibold">Create an account</a>
+  <a href={`${base}/signup/handle`} class="text-center text-sm font-semibold">Create an account</a>
 </div>

--- a/packages/apps/frequency-wallet-proxy/src/routes/signup/handle/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signup/handle/+page.svelte
@@ -33,7 +33,7 @@
   </div>
   <div class=" flex-col">
     <div class="flex">Select a key to associate with a handle</div>
-    <div class="flex pb-9">
+    <div class="pb-9">
       <WalletAddressSelector
         accounts={Object.values($FilteredNonMsaAccountsDerivedStore)}
         bind:selectedAccount


### PR DESCRIPTION
 # Description
This PR fixes the styling on the "claim handle" page when there is only a single address in the wallet. The checkmark is now appropriately positioned to the right of the selected address

Closes #135 