### PR TITLE
fix: do not connect to chain until signin request received from client

### DIFF
--- a/packages/apps/example/src/routes/+page.svelte
+++ b/packages/apps/example/src/routes/+page.svelte
@@ -3,6 +3,7 @@
     type Config,
     defaultConfig,
     getLoginOrRegistrationPayload,
+    type RequestedSchema,
     setConfig,
     type SignUpResponse,
     type WalletProxyResponse,
@@ -11,7 +12,7 @@
   import { parseMessage, SiwsMessage } from '@talismn/siws';
   import AccountCreator from '$lib/components/AccountCreator.svelte';
   import { MultiSelect, type ObjectOption, type Option } from 'svelte-multiselect';
-  import { type SchemaName, schemas } from '@dsnp/frequency-schemas/dsnp';
+  import { schemas } from '@dsnp/frequency-schemas/dsnp';
   import Spinner from '../lib/components/Spinner.svelte';
 
   if (process.env.BUILD_TARGET === 'production') {
@@ -32,16 +33,17 @@
   };
 
   const CHAIN_URLS: ChainUrl[] = [
-    {
-      name: 'Mainnet #1',
-      http: 'https://0.rpc.frequency.xyz',
-      ws: 'wss://0.rpc.frequency.xyz',
-    },
-    {
-      name: 'Mainnet #2',
-      http: 'https://1.rpc.frequency.xyz',
-      ws: 'wss://1.rpc.frequency.xyz',
-    },
+    // NOTE: Disable mainnet until schema names are deployed
+    // {
+    //   name: 'Mainnet #1',
+    //   http: 'https://0.rpc.frequency.xyz',
+    //   ws: 'wss://0.rpc.frequency.xyz',
+    // },
+    // {
+    //   name: 'Mainnet #2',
+    //   http: 'https://1.rpc.frequency.xyz',
+    //   ws: 'wss://1.rpc.frequency.xyz',
+    // },
     {
       name: 'Rococo',
       http: 'https://rpc.rococo.frequency.xyz',
@@ -73,7 +75,11 @@
   let chainUrl: ChainUrl;
   let loginUrl: ProxyUrl;
   let expirationSeconds: number = 300;
-  let requestedSchemas: Option[] = defaultConfig.schemas.map((s) => ({ label: s.name, value: s.name, id: s.id }));
+  let requestedSchemas: Option[] = defaultConfig.schemas.map((s) => ({
+    ...s,
+    label: s.name,
+    value: s.name,
+  }));
   let options = [...schemas.keys()];
   let providerId: number = 1;
   let isFetchingPayload = false;
@@ -86,7 +92,10 @@
       providerId: providerId.toString(),
       frequencyRpcUrl: chainUrl.http,
       proxyUrl: loginUrl.url,
-      schemas: requestedSchemas.map((option) => ({ name: (option as ObjectOption).value as SchemaName, id: 0 })),
+      schemas: requestedSchemas.map((option) => {
+        const { label: _label, value: _value, ...s } = option as unknown as ObjectOption;
+        return { ...s } as RequestedSchema;
+      }),
       siwsOptions: {
         expiresInMsecs: expirationSeconds * 1_000,
       },

--- a/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
+++ b/packages/apps/frequency-wallet-proxy/src/lib/stores/RequestResponseStore.ts
@@ -22,6 +22,7 @@ export type RequestResponseData = {
 function createRequestResponseStore() {
   const { subscribe, set, update } = writable<RequestResponseData>({
     request: {
+      frequencyRpcUrl: '',
       providerId: '',
       providerName: '',
       isNewProvider: true,

--- a/packages/apps/frequency-wallet-proxy/src/routes/+layout.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/+layout.svelte
@@ -3,18 +3,20 @@
   import { resolveInjectedWeb3 } from '$lib/stores/derived/ConnectedExtensionsDerivedStore';
   import FrequencyLogo from '$lib/icons/FrequencyLogo.svelte';
   import {
+    getApi,
     getProviderRegistryInfo,
     resolveSchemas,
     setApiUrl,
     type SignInRequest,
   } from '@frequency-control-panel/utils';
   import { RequestResponseStore } from '$lib/stores/RequestResponseStore';
-  import { page } from '$app/stores';
   import { getWindowEndpoint } from '$lib/utils';
 
   async function handleSigninPayload(e: CustomEvent) {
-    setApiUrl($page.url.searchParams.get('frequencyRpcUrl'));
+    console.dir(`Received signin request:
+${JSON.stringify(e.detail, (_, value) => value, 3)}`);
     const payload = e.detail as SignInRequest;
+    setApiUrl(payload.frequencyRpcUrl);
     await resolveSchemas(payload.requiredSchemas!);
     const providerName = await getProviderRegistryInfo(payload.providerId);
     RequestResponseStore.set({
@@ -40,6 +42,8 @@
     <div class="flex items-center justify-center pb-[60px] pt-[60px]">
       <svelte:component this={FrequencyLogo} />
     </div>
-    <slot />
+    {#await getApi() then}
+      <slot />
+    {/await}
   </div>
 </div>

--- a/packages/utils/src/frequency/connect.ts
+++ b/packages/utils/src/frequency/connect.ts
@@ -1,33 +1,46 @@
 import { ApiPromise, HttpProvider, WsProvider } from '@polkadot/api';
 import { options } from '@frequency-chain/api-augment';
 
-const FALLBACK_URL = 'http://127.0.0.1:9944/';
+let api: Promise<ApiPromise>;
+let nodeResolve: ((value: string) => void) | undefined;
+const rpcNodeUrl = new Promise<string>((resolve) => {
+  nodeResolve = resolve;
+});
 
-let api: ApiPromise | undefined = undefined;
-let rpcNodeUrl: string | null;
-
-export function setApiUrl(u: string | null) {
-  rpcNodeUrl = u;
+export function setApiUrl(u: string) {
+  console.log('Setting chain URL to ', u);
+  if (nodeResolve) {
+    nodeResolve(u);
+    nodeResolve = undefined;
+  }
 }
 
-export async function getApi(newUrl?: string): Promise<ApiPromise> {
-  if (api && (!newUrl || newUrl === rpcNodeUrl)) return api;
-  if (api) {
-    await api.disconnect();
-    api = undefined;
+/// Return a promise that will not resolve until:
+///   - the chain URL is set
+///   - the chain is successfully connected
+export async function getApi(): Promise<ApiPromise> {
+  if (!api) {
+    const url = await rpcNodeUrl;
+    api = new Promise<ApiPromise>((resolve, reject) => {
+      console.log('Connecting to ', url);
+      const provider = url.startsWith('http') ? new HttpProvider(url) : new WsProvider(url);
+
+      ApiPromise.create({
+        provider,
+        throwOnConnect: true,
+        throwOnUnknown: true,
+        ...options,
+      })
+        .then((value) => value.isReadyOrError)
+        .then((readyApi) => {
+          resolve(readyApi);
+        })
+        .catch((err) => {
+          console.error(err);
+          reject(err);
+        });
+    });
   }
-
-  rpcNodeUrl = newUrl || rpcNodeUrl || FALLBACK_URL;
-  const provider = rpcNodeUrl.startsWith('http') ? new HttpProvider(rpcNodeUrl) : new WsProvider(rpcNodeUrl);
-
-  api = await ApiPromise.create({
-    provider,
-    throwOnConnect: true,
-    throwOnUnknown: true,
-    ...options,
-  });
-
-  await api.isReadyOrError;
 
   return api;
 }

--- a/packages/utils/src/wallet-proxy/config.ts
+++ b/packages/utils/src/wallet-proxy/config.ts
@@ -4,23 +4,18 @@ import { RequestedSchema, type SiwsOptions } from './messenger';
 const defaultSchemas: RequestedSchema[] = [
   {
     name: 'profile',
-    id: 0,
   },
   {
     name: 'public-key-key-agreement',
-    id: 0,
   },
   {
     name: 'public-follows',
-    id: 0,
   },
   {
     name: 'private-follows',
-    id: 0,
   },
   {
     name: 'private-connections',
-    id: 0,
   },
 ];
 

--- a/packages/utils/src/wallet-proxy/messenger/types.ts
+++ b/packages/utils/src/wallet-proxy/messenger/types.ts
@@ -10,7 +10,7 @@ export type RequestedSchema = {
   version?: number;
 
   /// Resolved schema ID of the named/versioned schema.
-  id: number;
+  id?: number;
 };
 
 /// Data type to control optional parameters for "Sign in with Substrate"
@@ -35,6 +35,9 @@ export type SiwsOptions = {
 
 /// Data type representing a "Sign in with Frequency" request
 export type SignInRequest = {
+  /// Frequency chain RPC node to connect to
+  frequencyRpcUrl: string;
+
   /// Provider ID registered on-chain (technically a u64, but we use a string as bigints don't serialize/deserialize well)
   providerId: string;
 

--- a/packages/utils/src/wallet-proxy/popup.ts
+++ b/packages/utils/src/wallet-proxy/popup.ts
@@ -34,6 +34,7 @@ async function doGetLoginOrRegistrationPayload(): Promise<WalletProxyResponse> {
   const { providerId, proxyUrl, frequencyRpcUrl, schemas, siwsOptions } = getConfig();
 
   const signInRequest: SignInRequest = {
+    frequencyRpcUrl,
     providerId,
     requiredSchemas: schemas,
     siwsOptions,


### PR DESCRIPTION
 # Description
This PR fixes the issue where the MSAs in a wallet are not detected correctly at first

Closes #144 

## Details
The issue was due to the fact that at app initialization, we were at first connecting to the "default" chain (localhost), and so initially there were MSAs detected on the local chain. Then the chain connection was switched to the node/chain desired by the client (ie, rococo or mainnet), which contained no MSAs. But the check for MSAs present had already happened, and thus the user was directed incorrectly to the sign-in flow, which dynamically update to (correctly) show no MSAs available to sign in.

# Solution
Eliminated the concept of a "default" chain node; instead, obtaining a connection to the chain is a Promise that does not resolve until a node URL is set after receiving a signin request from the client.

Added benefit: we now no longer need to specify the chain URL as a route query parameter; it can be part of the signin request payload as originally intended.