### PR TITLE
fix(signin): ensure talisman login works

### DIFF
--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -92,7 +92,7 @@ export class ExtensionConnector {
     }
 
     try {
-      return await this.extension.accounts.get();
+      return (await this.extension.accounts.get()).filter((account: InjectedAccount) => account?.type !== 'ethereum');
     } catch (error) {
       console.error(error);
       throw new Error('Failed to request accounts', { cause: error });


### PR DESCRIPTION
Ensure that users can login with Talisman.

When fetching accounts from Talisman wallet
as part of the responce it returned non-supported
account keys. Ensure that ethereum keys are filtered out and user can signin and signup with Talisman.

#134 