### PR TITLE
feat: update Talisman SIWS package to add support for notBefore, requestId and resources fields

### DIFF
--- a/packages/apps/example/package.json
+++ b/packages/apps/example/package.json
@@ -49,7 +49,7 @@
 		"@polkadot/util-crypto": "^12.6.2",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@tailwindcss/forms": "^0.5.7",
-		"@talismn/siws": "^0.0.9",
+		"@talismn/siws": "^0.0.18",
 		"frequency-scenario-template": "link:../../../../frequency-scenario-template",
 		"svelte-multiselect": "^10.2.0"
 	}

--- a/packages/apps/example/src/lib/components/AccountCreator.svelte
+++ b/packages/apps/example/src/lib/components/AccountCreator.svelte
@@ -4,20 +4,14 @@
   import '@frequency-chain/api-augment';
   import { onMount } from 'svelte';
   import { Keyring } from '@polkadot/api';
-  import {
-    getApi,
-    setApiUrl,
-    type SignUpResponse,
-    validateSignupExtrinsicsParams,
-  } from '@frequency-control-panel/utils';
+  import { type SignUpResponse, validateSignupExtrinsicsParams } from '@frequency-control-panel/utils';
   import type { ApiPromise } from '@polkadot/api/promise';
   import Spinner from './Spinner.svelte';
 
   export let providerId: string;
   export let payload: SignUpResponse;
+  export let api: ApiPromise;
 
-  export let chainUrl: string;
-  let api: ApiPromise;
   let isWaiting = true;
   let events: PolkadotEventRecord[] = [];
   let error: Error;
@@ -27,16 +21,13 @@
   const keys = keyring.addFromMnemonic(PROVIDER_MNEMONIC);
 
   onMount(async () => {
-    setApiUrl(chainUrl);
-    api = await getApi();
     console.log('payload', payload);
-    console.log("providerID", providerId);
+    console.log('providerID', providerId);
     const validatedPaylod = await validateSignupExtrinsicsParams(payload?.extrinsics || [], providerId, api);
-    console.log("validatedPaylod", validatedPaylod);
+    console.log('validatedPaylod', validatedPaylod);
 
     const transactions = validatedPaylod.calls.map((e) => e.encodedExtrinsic);
     if (transactions?.length) {
-      api = await getApi();
       const txns = transactions?.map((t) => api.tx(t));
       const vec = api.registry.createType('Vec<Call>', txns);
       const createAccountTx = api.tx.frequencyTxPayment.payWithCapacityBatchAll(vec);

--- a/packages/apps/example/src/lib/components/SignInVerification.svelte
+++ b/packages/apps/example/src/lib/components/SignInVerification.svelte
@@ -3,11 +3,12 @@
   import { u8aToHex } from '@polkadot/util';
   import { parseJson, type SiwsMessage } from '@talismn/siws';
   import Icon from '@iconify/svelte';
-  import { doesPublicKeyControlMsa, getMsaForAddress } from '@frequency-control-panel/utils';
+  import { doesPublicKeyControlMsa } from '@frequency-control-panel/utils';
   import { onDestroy, onMount } from 'svelte';
 
   export let payload: SiwsMessage;
   export let signature: `0x${string}`;
+
   let signatureVerified: boolean = false;
   let payloadValid: boolean = false;
   let msaId: string;
@@ -39,18 +40,16 @@
   $: payloadValid = isPayloadValid(payload);
 
   $: {
-    // TODO: Need support from SIWS for the 'resources' property
-    // const resources = (payload as unknown as any)['resources'];
-    // const msaUri = resources?.[0] || '';
-    // msaId = /([0-9]*)$/.exec(msaUri)?.[1] || '';
-    getMsaForAddress(payload.address).then((value) => {
-      msaId = value;
-      if (msaId) {
-        doesPublicKeyControlMsa(msaId, payload.address).then((val) => {
-          msaOwnershipVerified = val;
-        });
-      }
-    });
+    const resources = payload.resources;
+    const msaUri = new URL(resources?.[0] || '');
+    msaId = msaUri.pathname.slice(2);
+    if (msaId) {
+      doesPublicKeyControlMsa(msaId, payload.address)
+        .then((value) => {
+          msaOwnershipVerified = value;
+        })
+        .catch((e) => console.log(e));
+    }
   }
 
   onMount(() => {

--- a/packages/apps/frequency-wallet-proxy/package.json
+++ b/packages/apps/frequency-wallet-proxy/package.json
@@ -52,7 +52,7 @@
     "@polkadot/types": "^10.11.2",
     "@polkadot/util": "^12.6.2",
     "@tailwindcss/forms": "^0.5.7",
-    "@talismn/siws": "^0.0.9",
+    "@talismn/siws": "^0.0.18",
     "autoprefixer": "^10.4.17",
     "bits-ui": "^0.18.1",
     "http-status-codes": "^2.3.0",

--- a/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
+++ b/packages/apps/frequency-wallet-proxy/src/routes/signin/confirm/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SiwsMessage } from '@talismn/siws';
+  import { Siws, SiwsMessage } from '@talismn/siws';
   import { generateSIWxNonce, type SignInResponse } from '@frequency-control-panel/utils';
   import { CurrentSelectedMsaAccountStore } from '$lib/stores/CurrentSelectedMsaAccountStore';
   import { ConnectedExtensionsDerivedStore } from '$lib/stores/derived/ConnectedExtensionsDerivedStore';
@@ -17,6 +17,7 @@
 
   const now = new Date();
   const payload: SiwsMessage = new SiwsMessage({
+    version: Siws.CURRENT_VERSION,
     domain: window.location.hostname,
     // TODO: Should use CAIP-10 conformant address here, work with Talisman to update their code
     // address: new PolkadotAddress('genesis', $CurrentSelectedMsaAccountStore.account.address).toString(),
@@ -34,24 +35,14 @@
     expirationTime: new Date(
       now.valueOf() + ($RequestResponseStore.request?.siwsOptions?.expiresInMsecs || 300000)
     ).valueOf(), // default 5 minutes
-    // notBefore: now,
-    // requestId: ? TBD pass-through from app
-    // resources: [`dsnp://${$CurrentSelectedAccountWithMsaStore.msaInfo.msaId}`],
+    notBefore: $RequestResponseStore.request?.siwsOptions?.notBefore || now.valueOf(),
+    requestId: $RequestResponseStore.request?.siwsOptions?.requestId,
+    resources: [`dsnp://${$CurrentSelectedMsaAccountStore.msaId}`],
   });
 
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  // Add optional fields not yet supported by siws
-  (payload as unknown as any)['version'] = '1.0';
-  (payload as unknown as any)['notBefore'] = $RequestResponseStore.request?.siwsOptions?.notBefore || now.valueOf();
-  if ($RequestResponseStore.request?.siwsOptions?.requestId) {
-    (payload as unknown as any)['requestId'] = $RequestResponseStore.request?.siwsOptions?.requestId;
-  }
-  const resources = [`dsnp://${$CurrentSelectedMsaAccountStore.msaId}`];
   if ($RequestResponseStore.request?.siwsOptions?.resources?.length) {
-    resources.push(...$RequestResponseStore.request.siwsOptions.resources);
+    payload.resources!.push(...$RequestResponseStore.request.siwsOptions.resources);
   }
-  (payload as unknown as any)['resources'] = resources;
-  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   async function signPayload() {
     const extension =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.1)
       '@talismn/siws':
-        specifier: ^0.0.9
-        version: 0.0.9(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
+        specifier: ^0.0.18
+        version: 0.0.18(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
       frequency-scenario-template:
         specifier: link:../../../../frequency-scenario-template
         version: link:../../../../frequency-scenario-template
@@ -166,8 +166,8 @@ importers:
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.1)
       '@talismn/siws':
-        specifier: ^0.0.9
-        version: 0.0.9(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
+        specifier: ^0.0.18
+        version: 0.0.18(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2)
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.17(postcss@8.4.33)
@@ -3100,8 +3100,8 @@ packages:
       tailwindcss: 3.4.1
     dev: false
 
-  /@talismn/siws@0.0.9(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2):
-    resolution: {integrity: sha512-11Dcw6hyR/mTOZK2xFZffUUf3oJeGLzc3SFNkZkRptFVNXFg8zGbQQxds0U9UULp+EnxLj3vZljLCCmTQy2aaQ==}
+  /@talismn/siws@0.0.18(@polkadot/api-contract@10.11.2)(@polkadot/api@10.11.2)(@polkadot/extension-dapp@0.46.6)(@polkadot/types@10.11.2)(@polkadot/util-crypto@12.6.2)(@polkadot/util@12.6.2):
+    resolution: {integrity: sha512-+SvoIYAKKiLmmnBzDplTnF1LlpEkYNz+8Gi/daU7kmaMvQ4d3elVmb05OKEeHQRb/6qZd8Ij4XOCr1VpbXO3zA==}
     peerDependencies:
       '@polkadot/api': ^10.10.1
       '@polkadot/extension-dapp': ^0.46.5


### PR DESCRIPTION
# Description
This PR updates the package dependency for `@talismn/siws` to include support for the optional sign-in payload fields `notBefore`, `requestId`, and `resources`.

Closes #74 