### PR TITLE
Proof field `created` should be optional

### DIFF
--- a/libraries/js/src/types/credential.ts
+++ b/libraries/js/src/types/credential.ts
@@ -13,7 +13,7 @@ interface SiwfResponseCredentialBase {
   credentialSubject: Record<string, unknown>;
   proof: {
     type: 'DataIntegrityProof';
-    created: string;
+    created?: string;
     verificationMethod: string;
     cryptosuite: 'eddsa-rdfc-2022';
     proofPurpose: 'assertionMethod';


### PR DESCRIPTION
The type of `proof.created` should be optional per the spec.

https://www.w3.org/TR/vc-data-model-2.0/