### PR TITLE
Fix issue with parquetjs importing

### DIFF
--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -14,4 +14,9 @@ export default defineConfig({
     'process.env.BASE_PATH_EXAMPLE': JSON.stringify(process.env.BASE_PATH_EXAMPLE),
     'process.env.BASE_PATH_UI': JSON.stringify(process.env.BASE_PATH_UI),
   },
+  resolve: {
+    alias: {
+      '@dsnp/parquetjs': '../../node_modules/@dsnp/parquetjs/dist/browser/parquet.js',
+    },
+  },
 });

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
     environment: 'jsdom',
     mockReset: true,
   },
+  resolve: {
+    alias: {
+      '@dsnp/parquetjs': '../../node_modules/@dsnp/parquetjs/dist/browser/parquet.js',
+    },
+  },
 });


### PR DESCRIPTION
# Problem

Parquet was:
1. Not being tree shaken out
2. Not pulling the browser version

# Solution

Force the browser version of it in vite.

Also talking with the maintainers of `@dsnp/frequency-schemas` and `@dsnp/schemas` into changing how parquet is included or splitting out that part of the package