### PR TITLE
fix: add check for credential not yet valid

### DIFF
--- a/libraries/js/src/credentials.ts
+++ b/libraries/js/src/credentials.ts
@@ -42,6 +42,11 @@ export async function validateGeneralCredential(
     throw new Error(`Credential Expired: ${credential.proof.validUntil}`);
   }
 
+  // Check credential issuance date
+  if (credential.validFrom && Date.parse(credential.validFrom) > Date.now()) {
+    throw new Error(`Credential Not Yet Valid: ${credential.validFrom}`);
+  }
+
   if (credential.proof.expirationDate && Date.parse(credential.proof.expirationDate) < Date.now()) {
     throw new Error(`Credential Expired: ${credential.proof.expirationDate}`);
   }


### PR DESCRIPTION
# Problem

Credential verification fails with the following error:

```text
[Nest] 3812  - 10/30/2024, 12:37:33 PM   DEBUG [AccountsControllerV2] Received Sign In With Frequency v2 callback
[Nest] 3812  - 10/30/2024, 12:37:33 PM   DEBUG [AccountsControllerV2] {"authorizationCode":"59e76266-621f-40d9-bf0d-42dad940bc9b"}
[Nest] 3812  - 10/30/2024, 12:37:33 PM    WARN [SiwfV2Service] Failed to retrieve valid payload from "authorizationCode"
[Nest] 3812  - 10/30/2024, 12:37:33 PM    WARN [SiwfV2Service] Object:
{
  "error": "Error: Unable to validate credential (VerifiedEmailAddressCredential, VerifiableCredential). Error:Unknown"
}

[Nest] 3812  - 10/30/2024, 12:37:33 PM   ERROR [AllExceptionsFilter] ErrorReference [CfbHJ4UFFeRdXT6maCie] : BadRequestException: Invalid response from `authorizationCode` payload fetch.
[Nest] 3812  - 10/30/2024, 12:37:33 PM   DEBUG [AllExceptionsFilter] {"statusCode":400,"errorReference":"CfbHJ4UFFeRdXT6maCie","message":"Invalid response from `authorizationCode` payload fetch.","error":"Bad Request"}

```
# Solution

Implement the following check, which passes the error through to `account-service` and eliminates `Unknown`.

```javascript
  if (credential.validFrom && Date.parse(credential.validFrom) > Date.now()) {
    throw new Error(`Credential Not Yet Valid: ${credential.validFrom}`);
  }
```

with @wesbiggs 

## Steps to Verify:

1. Setup gateway and run siwf `example.mjs`
2. Try to login with a previously created user credential.
3. If the the login fails, observe the updated log message below. Note, if the SIWF service is updated and re-deployed, this error should not occur.

## Screenshots (optional):
Fixed error log:
```
[Nest] 8073  - 10/31/2024, 9:40:53 AM   DEBUG [AccountsControllerV2] Received Sign In With Frequency v2 callback
[Nest] 8073  - 10/31/2024, 9:40:53 AM   DEBUG [AccountsControllerV2] {"authorizationCode":"4d312c44-8f7d-4419-b72e-2e7e9957845b"}
[Nest] 8073  - 10/31/2024, 9:40:53 AM    WARN [SiwfV2Service] Failed to retrieve valid payload from "authorizationCode"
[Nest] 8073  - 10/31/2024, 9:40:53 AM    WARN [SiwfV2Service] Object:
{
  "error": "Error: Credential Not Yet Valid: 2024-10-31T15:40:53.604+0000"
}

[Nest] 8073  - 10/31/2024, 9:40:53 AM   ERROR [AllExceptionsFilter] ErrorReference [pHiKzH2gz3o5iQNt3f5M] : BadRequestException: Invalid response from `authorizationCode` payload fetch.
[Nest] 8073  - 10/31/2024, 9:40:53 AM   DEBUG [AllExceptionsFilter] {"statusCode":400,"errorReference":"pHiKzH2gz3o5iQNt3f5M","message":"Invalid response from `authorizationCode` payload fetch.","error":"Bad Request"}
```