### PR TITLE
fix warning icon overflow, update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Documentation is written in [CommonMark Markdown](https://rust-lang.github.io/md
 - [Node.js v20+](https://nodejs.org)
 
 #### Local Development
-
+- Build the signed-request-generator: follow the "Development" and "Build" steps in [`tools/signed-request-generator/README.md`].
+- Copy the new Generator to the docs directory: `rm -Rf docs/src/Generator && cp -a tools/signed-request-generator/build docs/src/Generator`
+- `cd ../../docs`
 - Serve the HTML locally and watch for changes: `mdbook serve` or `mdbook serve -p <port, default 3000>`
 - For style edits see: [`docs/css/overrides.css`](./docs/css/overrides.css)
 - For changes to the custom preprocessor see: [`docs/preprocessors/README.md`](./docs/preprocessors/README.md)

--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -290,3 +290,23 @@ hr {
   color: var(--headers);
   margin: 20px 0;
 }
+
+.warning {
+  position: relative;
+}
+
+.warning:before {
+  position: absolute;
+  width: 2.5rem;
+  height: 3rem;
+  margin-inline-start: calc(-3rem + 7px);
+  content: 'ⓘ';
+  background-color: var(--bg);
+  color: var(--warning-border);
+  font-weight: bold;
+  font-size: 2rem;
+  top: -8px;
+  border-top: 38px white;
+  margin-right: 0.5em;
+}
+

--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -296,17 +296,8 @@ hr {
 }
 
 .warning:before {
-  position: absolute;
   width: 2.5rem;
-  height: 3rem;
   margin-inline-start: calc(-3rem + 7px);
-  content: 'ⓘ';
-  background-color: var(--bg);
-  color: var(--warning-border);
-  font-weight: bold;
-  font-size: 2rem;
   top: -8px;
-  border-top: 38px white;
   margin-right: 0.5em;
 }
-

--- a/tools/signed-request-generator/README.md
+++ b/tools/signed-request-generator/README.md
@@ -5,6 +5,7 @@ A simple site that generates signed requests for SIWF.
 ## Developing
 
 1. Build the `siwf` package
+
 ```shell
   cd ../../libraries/js
   npm install
@@ -12,11 +13,13 @@ A simple site that generates signed requests for SIWF.
   cd dist
   npm pack
 ```
+
 2. Change back to this directory and install the newly-built `siwf` package:
+
 ```shell
   npm install ../../libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz
-````
- 
+```
+
 4. Start a development server:
 
 ```bash

--- a/tools/signed-request-generator/README.md
+++ b/tools/signed-request-generator/README.md
@@ -5,16 +5,19 @@ A simple site that generates signed requests for SIWF.
 ## Developing
 
 1. Build the `siwf` package
-   - `cd ../../libraries/js`
-   - `npm install`
-   - `npm run build`
-   - `cd dist`
-   - `npm pack`
-2. Install the build `siwf` package
-
-   - `npm install ../../libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz`
-
-3. Start a development server:
+```shell
+  cd ../../libraries/js
+  npm install
+  npm run build
+  cd dist
+  npm pack
+```
+2. Change back to this directory and install the newly-built `siwf` package:
+```shell
+  npm install ../../libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz
+````
+ 
+4. Start a development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
# Problem
Warning icon overflows, obscuring warning text.  Fixes #222 
Checked on mobile, tablet and desktop widths in FireFox and Chrome.

# Solution
- Add some CSS to the overrides.
- Update READMEs to be clearer about how to serve docs

## Steps to Verify:
- Follow the updated directions for running `mdbook serve` 
- Verify that the icon overflow is fixed

## Screenshots (optional):
<img width="877" alt="Screenshot 2024-11-22 at 9 12 56 AM" src="https://github.com/user-attachments/assets/eb9a2eef-eaa2-4c5d-a92d-54c41666e3f4">
