### PR TITLE
update length of hex values to 6 chars

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -1,8 +1,8 @@
 {
   "colors": {
     "primary": "#54B2AB",
-    "light": "#fff",
-    "dark": "#000"
+    "light": "#ffffff",
+    "dark": "#000000"
   },
   "content": {
     "title": "Sign In With Frequency"


### PR DESCRIPTION
# Problem

HOT FIX to update hex values to 6 digits. The built in hex-parsers expect 6 digits

# Solution

changed to #ffffff and #000000
