### PR TITLE
Documentation fixes for #266

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Documentation is written in [CommonMark Markdown](https://rust-lang.github.io/md
 - [Node.js v20+](https://nodejs.org)
 
 #### Local Development
-- Build the signed-request-generator: follow the "Development" and "Build" steps in [`tools/signed-request-generator/README.md`].
+- Build the signed-request-generator: follow the "Development" and "Build" steps in `[tools/signed-request-generator/README.md]`.
 - Copy the new Generator to the docs directory: `rm -Rf docs/src/Generator && cp -a tools/signed-request-generator/build docs/src/Generator`
 - `cd ../../docs`
 - Serve the HTML locally and watch for changes: `mdbook serve` or `mdbook serve -p <port, default 3000>`

--- a/docs/src/DataStructures/ApplicationContext.md
+++ b/docs/src/DataStructures/ApplicationContext.md
@@ -16,7 +16,10 @@ The `credentialSubject` field should contain an object with the following fields
 - `id`: Your provider identifier, expressed as a DID.
 - `application`: A JSON object containing the following keys:
   - `name`: A map of one or more language tags to human-readable string values. Language tags should follow [BCP-47/RFC-5646](https://www.rfc-editor.org/rfc/rfc5646.html) (as used in the HTTP `Content-Language` header). A content language key of `"*"` indicates a wildcard or default value, as in HTTP.
-  - `logo`: A map of one or more language tags (as above) to objects containing a `url` property. The URL should resolve to an image in the PNG format. The recommended maximum image width for optimal client compatibility is 200 pixels.
+  - `logo`: A map of one or more language tags (as above) to objects containing a `url` property. The URL should resolve to an image in the PNG format. The recommended image size is 250 x 100 pixels.
+
+The credential SHOULD be signed by a trusted `issuer`.
+The issuer MAY be the provider's control key, expressed in `did:key` syntax.
 
 ### Example
 
@@ -32,14 +35,14 @@ This application context credential describes a hypothetical app called "My Soci
     "ApplicationContextCredential",
     "VerifiableCredential"
   ],
-  "issuer": "did:web:frequencyaccess.com",
+  "issuer": "did:key:z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
   "validFrom": "2025-02-12T21:28:08.289+0000",
   "credentialSchema": {
     "type": "JsonSchema",
     "id": "https://schemas.frequencyaccess.com/ApplicationContextCredential/bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq.json"
   },
   "credentialSubject": {
-    "id": "did:dsnp:123456",
+    "id": "did:key:z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
     "application": {
       "name": {
         "en": "My Social App",
@@ -54,7 +57,7 @@ This application context credential describes a hypothetical app called "My Soci
   },
   "proof": {
     "type": "DataIntegrityProof",
-    "verificationMethod": "did:web:frequencyaccess.com#z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
+    "verificationMethod": "did:key:z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD#z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
     "cryptosuite": "eddsa-rdfc-2022",
     "proofPurpose": "assertionMethod",
     "proofValue": "z4jArnPwuwYxLnbBirLanpkcyBpmQwmyn5f3PdTYnxhpy48qpgvHHav6warjizjvtLMg6j3FK3BqbR2nuyT2UTSWC"

--- a/docs/src/SignatureGeneration.md
+++ b/docs/src/SignatureGeneration.md
@@ -118,7 +118,7 @@ Note that any delegations that are granted by the user will apply to all applica
 The application context credential is a JSON-formatted verifiable credential that MAY be signed by a credential issuer.
 If you are integrating with Frequency Access, your application context details will be created as part of the provisioning process.
 
-For detailed information on the credential schema and properties, see the [full specification and example](./DataStructures/ApplicationContext.md).
+For detailed information on the credential schema and properties, see the [full specification and example](./DataStructures/All.html#application-context).
 
 ### Example Using TypeScript/JavaScript
 


### PR DESCRIPTION
Fix link to ApplicationContext details; change example to show as self-signed with did:key; fix link in top-level README.

n.b. This doesn't close #266, just plucks some low-hanging fruit.