### PR TITLE
feat: close the loop on allowing multiple loginUri validations

### DIFF
--- a/libraries/js/src/response.ts
+++ b/libraries/js/src/response.ts
@@ -24,11 +24,11 @@ export function hasChainSubmissions(result: SiwfResponse): boolean {
  * Validate a possible SIWF Response
  *
  * @param {unknown} response - A possible SIWF Response.
- * @param {string} loginMsgUri - The login message signed by the user should match this domain. (Default: localhost)
+ * @param {string | string[]} loginMsgUri - The login message signed by the user should match one of the supplied domains. (Default: localhost)
  *
  * @returns {Promise<SiwfResponse>} The validated response
  */
-export async function validateSiwfResponse(response: unknown, loginMsgUri: string): Promise<SiwfResponse> {
+export async function validateSiwfResponse(response: unknown, loginMsgUri: string | string[]): Promise<SiwfResponse> {
   await cryptoWaitReady();
 
   let body = response;

--- a/libraries/js/src/types/general.ts
+++ b/libraries/js/src/types/general.ts
@@ -2,7 +2,7 @@ import { validateAddress } from '@polkadot/util-crypto/address/validate';
 
 export interface SiwfOptions {
   endpoint: string;
-  loginMsgUri?: string;
+  loginMsgUri?: string | string[];
 }
 
 export interface SiwfPublicKey {


### PR DESCRIPTION
Missed a couple of spots in the last PR (#291) that added support for validating login payloads against a list of allowable URIs.