### PR TITLE
Switch the ChainType to a passthrough and add Options Documentation

### DIFF
--- a/libraries/js/README.md
+++ b/libraries/js/README.md
@@ -35,6 +35,16 @@ See [Markdown/GitHub Docs](../../docs/src/QuickStart.md) or
 | `VerifiedPhoneNumberCredential`  | Request for a verified SMS/Phone Number        |
 | `VerifiedGraphKeyCredential`     | Request for a the private graph encryption key |
 
+### SIWF Options
+
+| Parameter     | Description                                                                        |
+|---------------|------------------------------------------------------------------------------------|
+| `endpoint`    | The SIWF service URL endpoint                                                      |
+| `chainType`   | Used to make sure the signatures are generated and validated for the correct chain |
+| `loginMsgUri` | The URI(s) used to validate the CAIP-122 Login Messages                            |
+
+
+
 ### JS API Types
 
 Types are included with the exports for the package

--- a/libraries/js/src/payloads.ts
+++ b/libraries/js/src/payloads.ts
@@ -9,7 +9,6 @@ import {
 } from './types/payload.js';
 import { MakePropertyRequired, SiwfResponse } from './types/response.js';
 import {
-  getChainTypeFromEndpoint,
   serializeAddProviderPayloadHex,
   serializeClaimHandlePayloadHex,
   serializeItemActionsPayloadHex,
@@ -119,7 +118,7 @@ function verifySignatureMaybeWrapped(
   publicKey: string,
   signature: string,
   message: SignedPayload,
-  options: MakePropertyRequired<SiwfOptions, 'endpoint'>
+  options: SiwfOptions
 ): boolean {
   if (curveType === 'Sr25519' && isSignedPayloadUint8Array(message)) {
     const unwrappedVerifyResult = signatureVerify(message, signature, publicKey);
@@ -133,12 +132,7 @@ function verifySignatureMaybeWrapped(
 
     return wrappedVerifyResult.isValid || verifySignatureHashMaybeWrapped(publicKey, signature, message);
   } else if (curveType === 'Secp256k1' && isSignedPayloadSupportedPayload(message)) {
-    return verifySignature(
-      publicKey as HexString,
-      signature as HexString,
-      message,
-      getChainTypeFromEndpoint(options.endpoint)
-    );
+    return verifySignature(publicKey as HexString, signature as HexString, message, options.chainType);
   } else {
     throw new Error(`${curveType} is not supported!`);
   }
@@ -253,7 +247,7 @@ function validateLoginPayload(
         userPublicKey.encodedValue as HexString,
         payload.signature.encodedValue as HexString,
         createSiwfLoginRequestPayload(payload.payload.message),
-        getChainTypeFromEndpoint(options.endpoint)
+        options.chainType
       ),
       'Login message signature failed'
     );

--- a/libraries/js/src/payloads.ts
+++ b/libraries/js/src/payloads.ts
@@ -7,7 +7,7 @@ import {
   isPayloadLogin,
   SiwfResponsePayloadLogin,
 } from './types/payload.js';
-import { MakePropertyRequired, SiwfResponse } from './types/response.js';
+import { SiwfResponse } from './types/response.js';
 import {
   serializeAddProviderPayloadHex,
   serializeClaimHandlePayloadHex,

--- a/libraries/js/src/types/general.ts
+++ b/libraries/js/src/types/general.ts
@@ -1,8 +1,27 @@
 import { validateAddress } from '@polkadot/util-crypto/address/validate';
-import { SupportedPayload } from '@frequency-chain/ethereum-utils';
+import { ChainType, SupportedPayload } from '@frequency-chain/ethereum-utils';
 
 export interface SiwfOptions {
-  endpoint: string;
+  /**
+   * The SIWF service URL endpoint
+   * - `mainnet` Will default to Frequency Access Mainnet  (Default)
+   * - `testnet` Will default to Frequency Access Testnet
+   * - `<custom>` Will use the custom url
+   */
+  endpoint?: string;
+  /**
+   * Chain Type
+   * Used to make sure the signatures are generated and validated for the correct chain.
+   * EIP-712 ChainId is different for different chains
+   * Supported Chain Types:
+   * - `Mainnet-Frequency` (Default)
+   * - `Paseo-Testnet-Frequency`
+   * - `Dev`
+   */
+  chainType?: ChainType;
+  /**
+   * The URI(s) used to validate the CAIP-122 Login Messages
+   */
   loginMsgUri?: string | string[];
 }
 

--- a/libraries/js/src/util.ts
+++ b/libraries/js/src/util.ts
@@ -164,12 +164,3 @@ export function getAlgorithmForCurveType(keyType: CurveType): AlgorithmType {
       throw new Error(`${keyType} is not supported!`);
   }
 }
-
-export function getChainTypeFromEndpoint(endpoint: string): ChainType {
-  if (endpoint.toLowerCase() === 'production') {
-    return 'Mainnet-Frequency';
-  } else if (endpoint.toLowerCase() === 'staging') {
-    return 'Paseo-Testnet-Frequency';
-  }
-  return 'Dev';
-}

--- a/libraries/js/src/util.ts
+++ b/libraries/js/src/util.ts
@@ -10,7 +10,6 @@ import {
 } from './types/payload.js';
 import { AlgorithmType, CurveType, SignedPayload } from './types';
 import {
-  ChainType,
   createAddProvider,
   createClaimHandlePayload,
   createItemizedAddAction,


### PR DESCRIPTION
# Problem

The endpoint double use case was confusing. 

# Solution

Switched to just requiring the chainType to pass-through to Ethereum-Utils