### PR TITLE
Rollback @digitalcredentials/vc from v10 to v9 due to commonjs support

### DIFF
--- a/libraries/js/package-lock.json
+++ b/libraries/js/package-lock.json
@@ -14,7 +14,7 @@
         "@digitalcredentials/jsonld": "^9.0.0",
         "@digitalcredentials/jsonld-signatures": "^12.0.1",
         "@digitalcredentials/sha256-universal": "^1.1.1",
-        "@digitalcredentials/vc": "^10.0.0",
+        "@digitalcredentials/vc": "^9.0.1",
         "@frequency-chain/ethereum-utils": "^1.17.0",
         "@polkadot/keyring": "^13.5.3",
         "@polkadot/types": "^16.3.1",
@@ -2006,14 +2006,14 @@
       }
     },
     "node_modules/@digitalcredentials/vc": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/vc/-/vc-10.0.0.tgz",
-      "integrity": "sha512-yHSE2iJy/uhdboa7ybO+emGMiKAlhq4iRXvsteUWSoBtNE20CoBeSKJ1Fh06EhbzlOyLJSBg2s54C9dParehdw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/vc/-/vc-9.0.1.tgz",
+      "integrity": "sha512-oqwOq2mJqvrFabc/89jupkNkhhmFrOe93efSjCMmtd4XnM0Tcj3PYOq/ptmyXKpj8+vEqzeGxqF7AXiCMh3dig==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@digitalcredentials/credentials-v2-context": "^0.0.1-beta.0",
+        "@digitalcredentials/credentials-v2-context": "~0.0.1-beta.0",
         "@digitalcredentials/jsonld": "^9.0.0",
-        "@digitalcredentials/jsonld-signatures": "^12.0.1",
+        "@digitalcredentials/jsonld-signatures": "^12.0.0",
         "@digitalcredentials/open-badges-context": "^2.1.0",
         "credentials-context": "^2.0.0",
         "ed25519-signature-2018-context": "^1.1.0"

--- a/libraries/js/package.json
+++ b/libraries/js/package.json
@@ -48,7 +48,7 @@
     "@digitalcredentials/jsonld": "^9.0.0",
     "@digitalcredentials/jsonld-signatures": "^12.0.1",
     "@digitalcredentials/sha256-universal": "^1.1.1",
-    "@digitalcredentials/vc": "^10.0.0",
+    "@digitalcredentials/vc": "^9.0.1",
     "@frequency-chain/ethereum-utils": "^1.17.0",
     "@polkadot/keyring": "^13.5.3",
     "@polkadot/types": "^16.3.1",


### PR DESCRIPTION
# Problem

`@digitalcredentials/vc` v10 dropped support for Common JS. This caused issues downstream.
- https://github.com/digitalcredentials/vc/blob/main/CHANGELOG.md#1000---2025-04-30

# Solution

No current advantages to v10 over v9, so currently just downgrading to v9 to continue to have good CJS support.