### PR TITLE
fix: swap in noble-hashes for Node crypto:

### DIFF
--- a/libraries/js/package-lock.json
+++ b/libraries/js/package-lock.json
@@ -24,6 +24,7 @@
         "base-x": "^5.0.1",
         "base64url": "^3.0.1",
         "bs58": "^6.0.0",
+        "noble-hashes": "^0.3.1",
         "rdf-canonize": "^4.0.1",
         "tweetnacl": "^1.0.3"
       },
@@ -10589,6 +10590,13 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/noble-hashes": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/noble-hashes/-/noble-hashes-0.3.1.tgz",
+      "integrity": "sha512-TpYvlZvM8nGB582H9qQdTCLTNPS4TX9r5gkB4iiCWlO/URrdFJKAKwzwwEcNYPhLrcmCvBF1Nfm25GMbFWEplw==",
+      "deprecated": "Switch to namespaced @noble/hashes for security and feature updates",
+      "license": "MIT"
     },
     "node_modules/nock": {
       "version": "13.5.6",

--- a/libraries/js/package-lock.json
+++ b/libraries/js/package-lock.json
@@ -16,6 +16,7 @@
         "@digitalcredentials/sha256-universal": "^1.1.1",
         "@digitalcredentials/vc": "^9.0.1",
         "@frequency-chain/ethereum-utils": "^1.17.1",
+        "@noble/hashes": "^1.8.0",
         "@polkadot/keyring": "^13.5.3",
         "@polkadot/types": "^16.3.1",
         "@polkadot/types-codec": "^16.3.1",
@@ -24,7 +25,6 @@
         "base-x": "^5.0.1",
         "base64url": "^3.0.1",
         "bs58": "^6.0.0",
-        "noble-hashes": "^0.3.1",
         "rdf-canonize": "^4.0.1",
         "tweetnacl": "^1.0.3"
       },
@@ -10590,13 +10590,6 @@
       "license": "MIT",
       "optional": true,
       "peer": true
-    },
-    "node_modules/noble-hashes": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/noble-hashes/-/noble-hashes-0.3.1.tgz",
-      "integrity": "sha512-TpYvlZvM8nGB582H9qQdTCLTNPS4TX9r5gkB4iiCWlO/URrdFJKAKwzwwEcNYPhLrcmCvBF1Nfm25GMbFWEplw==",
-      "deprecated": "Switch to namespaced @noble/hashes for security and feature updates",
-      "license": "MIT"
     },
     "node_modules/nock": {
       "version": "13.5.6",

--- a/libraries/js/package.json
+++ b/libraries/js/package.json
@@ -58,6 +58,7 @@
     "base-x": "^5.0.1",
     "base64url": "^3.0.1",
     "bs58": "^6.0.0",
+    "noble-hashes": "^0.3.1",
     "rdf-canonize": "^4.0.1",
     "tweetnacl": "^1.0.3"
   },

--- a/libraries/js/package.json
+++ b/libraries/js/package.json
@@ -50,6 +50,7 @@
     "@digitalcredentials/sha256-universal": "^1.1.1",
     "@digitalcredentials/vc": "^9.0.1",
     "@frequency-chain/ethereum-utils": "^1.17.1",
+    "@noble/hashes": "^1.8.0",
     "@polkadot/keyring": "^13.5.3",
     "@polkadot/types": "^16.3.1",
     "@polkadot/types-codec": "^16.3.1",
@@ -58,7 +59,6 @@
     "base-x": "^5.0.1",
     "base64url": "^3.0.1",
     "bs58": "^6.0.0",
-    "noble-hashes": "^0.3.1",
     "rdf-canonize": "^4.0.1",
     "tweetnacl": "^1.0.3"
   },

--- a/libraries/js/src/vc/data-integrity/sha256digest.ts
+++ b/libraries/js/src/vc/data-integrity/sha256digest.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
-import crypto from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha2.js'; // ESM & Common.js
 
 /**
  * Hashes a string of data using SHA-256.
@@ -11,5 +11,5 @@ import crypto from 'node:crypto';
  * @returns {Uint8Array} The hash digest.
  */
 export async function sha256digest({ string }: { string: string }): Promise<Uint8Array> {
-  return new Uint8Array(crypto.createHash('sha256').update(string).digest());
+  return sha256(string);
 }


### PR DESCRIPTION
# Description
This PR removes the dependency on Node's built-in `node:crypto` module and instead uses the pure-JS `@noble/hashes` package. The resulting solution is pure JS and does not depend on Node built-ins, and is therefore more compatible with non-Node environments like React Native.

Closes #373 