### PR TITLE
add docs for ethr

### DIFF
--- a/docs/src/Actions/Response.md
+++ b/docs/src/Actions/Response.md
@@ -49,6 +49,7 @@ These credentials follow the [DSNP Verifiable Credentials Specification](https:/
 _Trust Model Note_: You may choose to just trust credentials issued by Frequency Access (or other SIWF-compatible services) given that the credential is fetched directly. These will have issuer `did:web:testnet.frequencyaccess.com` or `did:web:frequencyaccess.com`.
 Note that some credentials such as `VerifiedGraphKeyCredential` or `VerifiedRecoverySecretCredential` do not need a proof.
 
+#### Sr25519
 1. Check that the `credentialSubject.id` matches the `userPublicKey` following the [`did:key` Method from the W3C](https://w3c-ccg.github.io/did-key-spec/#format)
   - Example: `f6cL4wq1HUNx11TcvdABNf9UNXXoyH47mVUwT59tzSFRW8yDH` is the [SS58](https://docs.substrate.io/reference/address-formats/) version with prefix `90` of the hex address `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d`. `0xef01d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d` is multicodec `sr25519-pub` hex which is multiformat `base58-btc` `z6QNzHod3tSSJbwo4e5xGDcnsndsR9WByZzPoCGdbv3sv1jJ`
 2. Fetch the issuer DID Document following the [`did:web` Method from the W3C](https://w3c-ccg.github.io/did-method-web/)
@@ -57,6 +58,10 @@ Note that some credentials such as `VerifiedGraphKeyCredential` or `VerifiedReco
 3. Check that the key in the `proof.verificationMethod` is in the DID Document to verify that the key is still valid
 4. Test that the `proof` validates according the to [W3C Verifiable Credentials Specification](https://www.w3.org/TR/vc-data-model-1.1/#verification)
 
+#### Secp256k1
+1. Check that the `credentialSubject.id` matches the `userPublicKey` following the [`did:ethr` definition](https://github.com/uport-project/ethr-did)
+   - Example: `0x34c20Ac587999E44AFC39A239b8AB9f243e73c2A` is the Ethereum address associated with used `Secp256k1` key is represented as `did:ethr:0x34c20Ac587999E44AFC39A239b8AB9f243e73c2A`
+2. Currently, there is no proof associated with these keys.
 
 #### Graph Encryption Key Credential
 

--- a/docs/src/DataStructures/ApplicationContext.md
+++ b/docs/src/DataStructures/ApplicationContext.md
@@ -19,12 +19,15 @@ The `credentialSubject` field should contain an object with the following fields
   - `logo`: A map of one or more language tags (as above) to objects containing a `url` property. The URL should resolve to an image in the PNG format. The recommended image size is 250 x 100 pixels.
 
 The credential SHOULD be signed by a trusted `issuer`.
-The issuer MAY be the provider's control key, expressed in `did:key` syntax.
+The issuer MAY be the provider's control key, expressed as one of the following formats
+  - `Sr25519` keys : follows `did:key` syntax.
+  - `Secp256k1` keys : follows `did:ethr` syntax. There are no proofs associated with these keys.
 
 #### Example
 
 This application context credential describes a hypothetical app called "My Social App".
 
+##### Sr25519
 ```json
 {
   "@context": [
@@ -61,6 +64,40 @@ This application context credential describes a hypothetical app called "My Soci
     "cryptosuite": "eddsa-rdfc-2022",
     "proofPurpose": "assertionMethod",
     "proofValue": "z4jArnPwuwYxLnbBirLanpkcyBpmQwmyn5f3PdTYnxhpy48qpgvHHav6warjizjvtLMg6j3FK3BqbR2nuyT2UTSWC"
+  }
+}
+```
+
+##### Secp256k1
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/undefined-terms/v2"
+  ],
+  "type": [
+    "ApplicationContextCredential",
+    "VerifiableCredential"
+  ],
+  "issuer": "did:ethr:0x34c20Ac587999E44AFC39A239b8AB9f243e73c2A",
+  "validFrom": "2025-02-12T21:28:08.289+0000",
+  "credentialSchema": {
+    "type": "JsonSchema",
+    "id": "https://schemas.frequencyaccess.com/ApplicationContextCredential/bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq.json"
+  },
+  "credentialSubject": {
+    "id": "did:ethr:0x34c20Ac587999E44AFC39A239b8AB9f243e73c2A",
+    "application": {
+      "name": {
+        "en": "My Social App",
+        "es": "Mi Aplicación Social"
+      },
+      "logo": {
+        "*": {
+          "url": "https://example.org/logos/my-social-app.png"
+        }
+      }
+    }
   }
 }
 ```

--- a/tools/signed-request-generator/package-lock.json
+++ b/tools/signed-request-generator/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "signed-request-generator",
 			"version": "0.0.1",
 			"dependencies": {
-				"@frequency-chain/ethereum-utils": "^1.17.1",
+				"@frequency-chain/ethereum-utils": "^1.17.2",
 				"@polkadot/extension-dapp": "^0.61.1",
 				"@polkadot/extension-inject": "^0.61.1",
 				"@projectlibertylabs/siwf": "file:../../libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz"

--- a/tools/signed-request-generator/package.json
+++ b/tools/signed-request-generator/package.json
@@ -15,7 +15,7 @@
 		"format": "prettier --write ."
 	},
 	"dependencies": {
-		"@frequency-chain/ethereum-utils": "^1.17.1",
+		"@frequency-chain/ethereum-utils": "^1.17.2",
 		"@polkadot/extension-dapp": "^0.61.1",
 		"@polkadot/extension-inject": "^0.61.1",
 		"@projectlibertylabs/siwf": "file:../../libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz"


### PR DESCRIPTION
# Description

We are going to use [`did:ethr`](https://github.com/uport-project/ethr-did) syntax for issuers with Secp254k1 keys.
Adding some docs regarding this change

