### PR TITLE
Add esm specific exports for better tree-shaking

### DIFF
--- a/libraries/js/scripts/package.cjs
+++ b/libraries/js/scripts/package.cjs
@@ -33,6 +33,31 @@ rootPackage['exports'] = {
     import: './esm/index.js',
     default: './esm/index.js',
   },
+  './request': {
+    types: './request.d.ts',
+    import: './esm/request.js',
+    require: './cjs/index.js',
+  },
+  './response': {
+    types: './response.d.ts',
+    import: './esm/response.js',
+    require: './cjs/index.js',
+  },
+  './start': {
+    types: './start.d.ts',
+    import: './esm/start.js',
+    require: './cjs/index.js',
+  },
+  './constants': {
+    types: './constants.d.ts',
+    import: './esm/constants.js',
+    require: './cjs/index.js',
+  },
+  './types': {
+    types: './types.d.ts',
+    import: './esm/types/index.js',
+    require: './cjs/index.js',
+  },
 };
 // Write it out
 fs.writeFileSync(`${path.join(__dirname, '../dist', 'package.json')}`, JSON.stringify(rootPackage, null, 2), (err) => {


### PR DESCRIPTION
# Problem

ESM tree-shaking helps applications greatly reduce the included code that is unneeded. This change adds the base level exports so that imports can use things like:

```
import { VerifiedRecoverySecret } from "@projectlibertylabs/siwf/constants";
import { decodeSignedRequest } from "@projectlibertylabs/siwf/request";
```