### PR TITLE
add digitalcredentials and noble/hashes to noExternal list

### DIFF
--- a/libraries/js/tsup.config.ts
+++ b/libraries/js/tsup.config.ts
@@ -8,7 +8,17 @@ export default defineConfig({
   format: 'cjs',
   platform: 'node',
   outDir: 'dist/cjs',
-  noExternal: [/digitalbazaar/, /base64url/, /base58/, /base-x/, 'bs58'],
+  noExternal: [
+      '@digitalcredentials/vc',
+      '@digitalcredentials/jsonld',
+      '@digitalcredentials/jsonld-signatures',
+      '@noble/hashes',
+      /digitalbazaar/,
+      /base64url/,
+      /base58/,
+      /base-x/,
+      'bs58'
+  ],
   outExtension() {
     return {
       js: `.js`,


### PR DESCRIPTION
# Problem
digitalcredentials and noble/hashes stopped supporting cjs.  This breaks gateway tests for updates to the latest siwf version.

# Solution
add them to the noExternal list in tsup.config.ts

# To Verify
In siwf:
```shell
cd libraries/js
npm run build
cd dist && npm pack
```
In gateway, check out the `update_to_latest` branch, and install the package:
```shell
npm install ../siwf/libraries/js/dist/projectlibertylabs-siwf-0.0.0.tgz 
```

Then you can run this script to verify that it builds and all tests pass. For extra credit you can run it before and after installing the built package to see red/green:

```shell
#!/usr/bin/env bash
set -a
# be sure to start the chain first; this doesn't bother checking

# set to wherever you have the repo checked out
ROOT_DIR="${HOME}/github/gateway"

exit_err(){
  echo "ERROR: $1"
  exit 1
}

NPMCI="npm ci --dry-run --no-audit --silent"

${NPMCI} || exit_err "root dir npm ci failed"
for app in account-api graph-api ; do
  appsetup="${ROOT_DIR}/apps/${app}/test/setup"
  pushd ${appsetup} || exit_err "couldn't change to ${app}"
  ${NPMCI} || exit_err "${app} npm ci failed"
  popd
done
cd ${ROOT_DIR}
npm run build:account || exit_err "npm run build failed"
npm run test
npm run test:e2e:account
```